### PR TITLE
Fix bug in obj_eval.py

### DIFF
--- a/lib/obj_evaluator/obj_eval.py
+++ b/lib/obj_evaluator/obj_eval.py
@@ -112,11 +112,11 @@ class ObjectEvaluator(object):
              det_boxes = detections[i]
 
              det_idx = range(len(detections[i]))
-
+             matched_det_idx = []
              for gt_box in ann['rects']:
                  # get list of IoU for the current ground truth box wrt all detections
                  iou = get_iou_list(gt_box, det_boxes)
-                 matched_det_idx = []
+                 
                  # all detections with IoU > threshold are detection matches for the current gt box
                  match = []
                  for e in det_idx:


### PR DESCRIPTION
`matched_det_idx` should be created outside the second for loop; otherwise an empty list is created for each `gt_box` causing wrong behavior: True positives that are already in `match_list` are also added to `fp_list` making the number of false positives look more than it actually is.